### PR TITLE
Feature/issue98 image only rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ All sorts of contributions are most welcome and appreciated. To start contributi
 
 The average response time for issues, PRs and emails is usually 24 hours. In some cases, it might be longer.
 
+## Setting up VS Code Remote development in WSL
+In order to speed up development, most development tasks (apart from the actual rending to E-Ink display) can be developed on more powerful machines and in richer environments than running this on a Pi zero. In case of Windows PC the most convenient way is to use VS Code Remote development in Windows Subsystem for Linux (WSL), please follow [Tutorial](https://code.visualstudio.com/remote-tutorials/wsl/getting-started). 
+
 ### Don't forget to check out the Wiki. It contains all the information to understanding and customising the script.
 
 **P.S:** Don't forget to star and/or watch the repo. For those who have done so already, thank you very much!

--- a/modules/inkycal.py
+++ b/modules/inkycal.py
@@ -13,6 +13,7 @@ from configuration import *
 import arrow
 from time import sleep
 import gc
+import logging
 
 """Perepare for execution of main programm"""
 calibration_countdown = 'initial'
@@ -57,23 +58,23 @@ while True:
     print('-----------Main programm started now----------')
 
     """------------------Calibration check----------------"""
-    if skip_calibration != True:
-      print('Calibration..', end = ' ')
-      if now.hour in calibration_hours:
-        if calibration_countdown == 'initial':
-          print('required. Performing calibration now.')
-          calibration_countdown = 0
-          calibrate_display(3)
-        else:
-          if calibration_countdown % (60 // int(update_interval)) == 0:
-            calibrate_display(3)
+    if eink_in_use:
+      if skip_calibration != True:
+        print('Calibration..', end = ' ')
+        if now.hour in calibration_hours:
+          if calibration_countdown == 'initial':
+            print('required. Performing calibration now.')
             calibration_countdown = 0
+            calibrate_display(3)
+          else:
+            if calibration_countdown % (60 // int(update_interval)) == 0:
+              calibrate_display(3)
+              calibration_countdown = 0
+        else:
+          print('not required. Continuing...')
       else:
-        print('not required. Continuing...')
-    else:
-      print('Calibration skipped!. Please note that not calibrating e-paper',
+        print('Calibration skipped!. Please note that not calibrating e-paper',
             'displays causes ghosting')
-
 
     """----------------------top-section-image-----------------------------"""
     try:
@@ -132,23 +133,24 @@ while True:
       image_col.save(image_path+'canvas_col.png')
 
     """---------Refreshing E-Paper with newly created image-----------"""
-    epaper = driver.EPD()
-    print('Initialising E-Paper...', end = '')
-    epaper.init()
-    print('Done')
-
-    if three_colour_support == True:
-      print('Sending image data and refreshing display...', end='')
-      epaper.display(epaper.getbuffer(image), epaper.getbuffer(image_col))
-      print('Done')
-    else:
-      print('Sending image data and refreshing display...', end='')
-      epaper.display(epaper.getbuffer(image))
+    if eink_in_use:
+      epaper = driver.EPD()
+      print('Initialising E-Paper...', end = '')
+      epaper.init()
       print('Done')
 
-    print('Sending E-Paper to deep sleep...', end = '')
-    epaper.sleep()
-    print('Done')
+      if three_colour_support == True:
+        print('Sending image data and refreshing display...', end='')
+        epaper.display(epaper.getbuffer(image), epaper.getbuffer(image_col))
+        print('Done')
+      else:
+        print('Sending image data and refreshing display...', end='')
+        epaper.display(epaper.getbuffer(image))
+        print('Done')
+
+      print('Sending E-Paper to deep sleep...', end = '')
+      epaper.sleep()
+      print('Done')
 
     """--------------Post processing after main loop-----------------"""
     """Collect some garbage to free up some resources"""

--- a/settings/configuration.py
+++ b/settings/configuration.py
@@ -282,9 +282,10 @@ def fix_ical(ical_url):
 
 def image_cleanup():
   """Delete all files in the image folder"""
-  print('Cleanup of previous images...', end = '')
-  for temp_files in glob(image_path+'*'):
-      os.remove(temp_files)
+  if eink_in_use:
+    print('Cleanup of previous images...', end = '')
+    for temp_files in glob(image_path+'*'):
+        os.remove(temp_files)
   print('Done')
 
 def optimise_colours(image, threshold=220):

--- a/settings/configuration.py
+++ b/settings/configuration.py
@@ -17,20 +17,63 @@ import os
 from glob import glob
 import importlib
 import subprocess as subp
+import logging
+
+"""Check if we have image-only rendering"""
+if render_target == 'image_only':
+  logging.basicConfig(level = logging.DEBUG)
+  eink_in_use = False
+else:
+  logging.basicConfig(level = logging.INFO)
+  eink_in_use = True
+
+logging.debug('Target: %s' % render_target)
+
+# TODO: refactoring is needed
+
+"""Function returns display's parameter according to the model name"""
+def get_display_parameters(model_name):
+  width, height = 0, 0
+  if 'colour' in model_name:
+    three_colour_support = True
+  else:
+    three_colour_support = False
+
+  if model_name == 'epd_7_in_5_v2_colour' or model_name == 'epd_7_in_5_v2':
+    width = 800
+    height = 480
+  elif model_name == 'epd_7_in_5_colour' or model_name == 'epd_7_in_5':
+    width = 640
+    height = 384
+  elif model_name == 'epd_5_in_83_colour' or model_name == 'epd_5_in_83':
+    width = 600
+    height = 448
+  elif model_name == 'epd_4_in_2_colour' or model_name == 'epd_4_in_2':
+    width = 400
+    height = 300
+  else:
+    logging.error('Unsupported display model: %s' % model_name)
+
+  logging.debug('Display model: %s' %  model_name)
+  logging.debug('Width, Height, 3-colours: %d, %d, %s' % (width, height, three_colour_support))
+  return width, height, three_colour_support
 
 """Set the image background colour and text colour"""
 background_colour = 'white'
 text_colour = 'black'
 
 """Set some display parameters"""
-driver = importlib.import_module('drivers.'+model)
-display_height, display_width = driver.EPD_WIDTH, driver.EPD_HEIGHT
+display_height, display_width, three_colour_support = get_display_parameters(model)
+if eink_in_use:
+  driver = importlib.import_module('drivers.'+model)
+  if display_height != driver.EPD_HEIGHT or display_width != driver.EPD_WIDTH:
+    logging.error('Inconsistency in display sizes:')
+    logging.error('Driver: %d x %d' % (driver.EPD_HEIGHT, driver.EPD_WIDTH))
+    logging.error('Config: %d x %d' % (display_height, display_width))
+    # Grab driver's sizes
+    display_height = driver.EPD_HEIGHT
+    display_width = driver.EPD_WIDTH
 
-"""Check if the display supports 3 colours"""
-if 'colour' in model:
-  three_colour_support = True
-else:
-  three_colour_support = False
 
 """Create 3 sections of the display, based on percentage"""
 top_section_width = middle_section_width = bottom_section_width = display_width
@@ -99,7 +142,6 @@ image_col = Image.new('RGB', (display_width, display_height), 'white')
 
 draw = ImageDraw.Draw(image)
 draw_col = ImageDraw.Draw(image_col)
-
 
 """Custom function to add text on an image"""
 def write_text(space_width, space_height, text, tuple,

--- a/settings/configuration.py
+++ b/settings/configuration.py
@@ -56,7 +56,7 @@ def get_display_parameters(model_name):
 
   logging.debug('Display model: %s' %  model_name)
   logging.debug('Width, Height, 3-colours: %d, %d, %s' % (width, height, three_colour_support))
-  return width, height, three_colour_support
+  return height, width, three_colour_support
 
 """Set the image background colour and text colour"""
 background_colour = 'white'

--- a/settings/configuration.py
+++ b/settings/configuration.py
@@ -63,16 +63,18 @@ background_colour = 'white'
 text_colour = 'black'
 
 """Set some display parameters"""
-display_height, display_width, three_colour_support = get_display_parameters(model)
+# Width and Height as swapped - display is rotated by 90 degree. TODO: refactoring
+display_width, display_height, three_colour_support = get_display_parameters(model)
+
 if eink_in_use:
   driver = importlib.import_module('drivers.'+model)
-  if display_height != driver.EPD_HEIGHT or display_width != driver.EPD_WIDTH:
+  if display_width != driver.EPD_HEIGHT or display_height != driver.EPD_WIDTH:
     logging.error('Inconsistency in display sizes:')
     logging.error('Driver: %d x %d' % (driver.EPD_HEIGHT, driver.EPD_WIDTH))
     logging.error('Config: %d x %d' % (display_height, display_width))
     # Grab driver's sizes
-    display_height = driver.EPD_HEIGHT
-    display_width = driver.EPD_WIDTH
+    display_width = driver.EPD_HEIGHT
+    display_height = driver.EPD_WIDTH
 
 
 """Create 3 sections of the display, based on percentage"""

--- a/settings/settings.py
+++ b/settings/settings.py
@@ -13,6 +13,7 @@ top_section = "inkycal_weather"       # "inkycal_weather"
 middle_section = "inkycal_calendar"   # "inkycal_agenda" # "inkycal_calendar"
 bottom_section = "inkycal_rss"        # "inkycal_rss"
 display_orientation = "normal"        # "normal" # "upside_down"
+render_target = "image_only"          # "eink" # "image_only"
 
 """Adding multiple iCalendar URLs or RSS feed URLs"""
 # Single URL:


### PR DESCRIPTION
New settings parameter:
`render_target = "image_only"          # "eink" # "image_only"`

If it set to `image_only`, all E-ink related calls are ignored, rendered images are not deleted:

```
...:~/Inky-Calendar/modules$ python3 inkycal.py 
DEBUG:root:Target: image_only
DEBUG:root:Display model: epd_7_in_5_v2_colour
DEBUG:root:Width, Height, 3-colours: 800, 480, True
Done
Initialising weather... Done
Calendar module: Generating image...Done
RSS module: Connectivity check passed. Generating image...Done
Current Date: 15 Apr 2020 
Current Time: 00:15
-----------Main programm started now----------
[Errno 2] No such file or directory: '/home/../Inky-Calendar/images/inkycal_weather.png'
Calendar module: Generating image...Done
DEBUG:PIL.PngImagePlugin:STREAM b'IHDR' 16 13
DEBUG:PIL.PngImagePlugin:STREAM b'IDAT' 41 17352
DEBUG:PIL.PngImagePlugin:STREAM b'IHDR' 16 13
DEBUG:PIL.PngImagePlugin:STREAM b'IDAT' 41 2598
RSS module: Connectivity check passed. Generating image...Done
DEBUG:PIL.PngImagePlugin:STREAM b'IHDR' 16 13
DEBUG:PIL.PngImagePlugin:STREAM b'IDAT' 41 11074
DEBUG:PIL.PngImagePlugin:STREAM b'IHDR' 16 13
DEBUG:PIL.PngImagePlugin:STREAM b'IDAT' 41 701
45 Minutes left until next refresh
Done
```
