### PR TITLE
Settings parameter to show only begin date

### DIFF
--- a/modules/inkycal_calendar.py
+++ b/modules/inkycal_calendar.py
@@ -147,12 +147,15 @@ def generate_image():
         """Find days with events in the current month"""
         days_with_events = []
         for events in events_this_month:
-          if events.duration.days <= 1:
+          if show_event_begin_only == 'true':
             days_with_events.append(int(events.begin.format('D')))
-          elif events.duration.days > 1:
-            for day in range(events.duration.days):
-              days_with_events.append(
-                int(events.begin.replace(days=+i).format('D')))
+          else:
+            if events.duration.days <= 1:
+              days_with_events.append(int(events.begin.format('D')))
+            elif events.duration.days > 1:
+              for day in range(events.duration.days):
+                days_with_events.append(
+                  int(events.begin.replace(days=+day).format('D')))
         days_with_events = set(days_with_events)
 
         if event_icon == 'dot':

--- a/settings/settings.py
+++ b/settings/settings.py
@@ -13,7 +13,8 @@ top_section = "inkycal_weather"       # "inkycal_weather"
 middle_section = "inkycal_calendar"   # "inkycal_agenda" # "inkycal_calendar"
 bottom_section = "inkycal_rss"        # "inkycal_rss"
 display_orientation = "normal"        # "normal" # "upside_down"
-render_target = "image_only"          # "eink" # "image_only"
+render_target = "eink"                # "eink" # "image_only"
+show_event_begin_only = "false"       # "true" # "false"
 
 """Adding multiple iCalendar URLs or RSS feed URLs"""
 # Single URL:


### PR DESCRIPTION
A new settings:
`show_event_begin_only = "false" # "true" # "false"`

When set to `true` then the only begin date of events are highlighted in Calendar.