### PR TITLE
Weather timezone fixes

### DIFF
--- a/modules/inkycal_weather.py
+++ b/modules/inkycal_weather.py
@@ -171,7 +171,7 @@ def generate_image():
       forecast = owm.three_hours_forecast(location)
 
       """Round the hour to the nearest multiple of 3"""
-      now = arrow.utcnow().to(get_tz())
+      now = arrow.utcnow()
       if (now.hour % 3) != 0:
         hour_gap = 3 - (now.hour % 3)
       else:
@@ -184,10 +184,10 @@ def generate_image():
       fc4 = now.replace(hours = + hour_gap + 9).floor('hour')
 
       """Prepare forecast objects for the specified timings"""
-      forecast_fc1 = forecast.get_weather_at(fc1.datetime.astimezone(timezone('UTC')))
-      forecast_fc2 = forecast.get_weather_at(fc2.datetime.astimezone(timezone('UTC')))
-      forecast_fc3 = forecast.get_weather_at(fc3.datetime.astimezone(timezone('UTC')))
-      forecast_fc4 = forecast.get_weather_at(fc4.datetime.astimezone(timezone('UTC')))
+      forecast_fc1 = forecast.get_weather_at(fc1.datetime)
+      forecast_fc2 = forecast.get_weather_at(fc2.datetime)
+      forecast_fc3 = forecast.get_weather_at(fc3.datetime)
+      forecast_fc4 = forecast.get_weather_at(fc4.datetime)
 
       """Get the current temperature and forcasts temperatures"""
       temperature_now = to_units(weather.get_temperature()['temp'])

--- a/modules/inkycal_weather.py
+++ b/modules/inkycal_weather.py
@@ -283,7 +283,7 @@ def generate_image():
                  fill_width = 0.9)
 
       """Add weather details in column 4 (forecast 1)"""
-      write_text(coloumn_width, row_height, to_hours(fc1, simple=True),
+      write_text(coloumn_width, row_height, to_hours(fc1.to(get_tz()), simple=True),
         text_fc1_pos, font = font)
       write_text(coloumn_width, row_height, weathericons[weather_icon_fc1],
         icon_fc1_pos, font = w_font, fill_height = 1.0)
@@ -292,7 +292,7 @@ def generate_image():
           temperature_fc1))
 
       """Add weather details in column 5 (forecast 2)"""
-      write_text(coloumn_width, row_height, to_hours(fc2, simple=True),
+      write_text(coloumn_width, row_height, to_hours(fc2.to(get_tz()), simple=True),
         text_fc2_pos, font = font)
       write_text(coloumn_width, row_height, weathericons[weather_icon_fc2],
         icon_fc2_pos, font = w_font, fill_height = 1.0)
@@ -301,7 +301,7 @@ def generate_image():
           temperature_fc2))
 
       """Add weather details in column 6 (forecast 3)"""
-      write_text(coloumn_width, row_height, to_hours(fc3, simple=True),
+      write_text(coloumn_width, row_height, to_hours(fc3.to(get_tz()), simple=True),
         text_fc3_pos, font = font)
       write_text(coloumn_width, row_height, weathericons[weather_icon_fc3],
         icon_fc3_pos, font = w_font, fill_height = 1.0)
@@ -310,7 +310,7 @@ def generate_image():
           temperature_fc3))
 
       """Add weather details in coloumn 7 (forecast 4)"""
-      write_text(coloumn_width, row_height, to_hours(fc4, simple=True),
+      write_text(coloumn_width, row_height, to_hours(fc4.to(get_tz()), simple=True),
         text_fc4_pos, font = font)
       write_text(coloumn_width, row_height, weathericons[weather_icon_fc4],
         icon_fc4_pos, font = w_font, fill_height = 1.0)


### PR DESCRIPTION
Instead of changing the timezone at the beginning (before the forecast is called) and temporarily changing it back to UTC for the forecast call, I just waited and changed the timezone at the end when the hour is displayed. This avoids the problem I had with it calling the forecast for the wrong time. I've been testing it all weekend and it doesn't appear to have any problems.